### PR TITLE
fix tags bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ hexo.extend.migrator.register('ghost', function(args, callback){
         };
 
         if (!isPage) {
-          postData.tags = post.tags && ('\n- ' + (post.tags).join('\n- '));
+          postData.tags = post.tags;
           postData.layout = post.status === 'published' ? 'post' : 'draft';
         }
         else {


### PR DESCRIPTION
我使用的ghost 0.7.2，Hexo 3.2.0。

对一个post，原先会生成（示例）：

```
title: learn linux
tags: |-
  - linux

---
```

修复后成为：

```
title: learn linux
tags:
  - linux

---
```
