### PR TITLE
Fix data path for old versions of Ghost.

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ hexo.extend.migrator.register('ghost', function(args, callback){
 
     try {
       data = JSON.parse(data);
-      data = data.db[0].data;
+      data = data.db ? data.db[0].data : data.data;
 
       var posts = data.posts;
       var postsTags = data.posts_tags;


### PR DESCRIPTION
I am using very old version of Ghost therefore my `GhostData.json` doesn't have `db` array. In my case it was `data.data` without `.db[0].`. Your migrator throw an error with my old `GhostData.json` and I debug it and find out that in my case there is no `db` in data object. After I did the minor change, everything worked as expected, and thank you for this migrator 👍 

I added a defensive check to handle old `GhostData.json`. Feel free to close this PR if you don't want to deal with older versions of Ghost. Although everything will work as before with my changes.